### PR TITLE
refactor(*): add params class; use releases

### DIFF
--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -1,13 +1,13 @@
 # == Class: envconsul::fetch
 
 class envconsul::fetch (
-  $base_url  = 'https://github.com/hashicorp/envconsul/releases/download',
+  $base_url  = "${envconsul::releases_url}/${envconsul::version}",
   $base_name = "envconsul_${envconsul::version}_${envconsul::platform}_${envconsul::arch}",
-  $extension = '.tar.gz',
+  $extension = $envconsul::extension,
 ){
 
   $file_name = "${base_name}${extension}"
-  $file_url  = "${base_url}/v${envconsul::version}/${file_name}"
+  $file_url  = "${base_url}/${file_name}"
 
   wget::fetch { $file_url:
     destination => "/tmp/${file_name}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,10 +34,13 @@
 # Copyright 2015 Reppard Walker, unless otherwise noted.
 #
 class envconsul (
-  $version  = '0.5.0',
-  $platform = 'linux',
-  $arch     = 'amd64',
-){
+  $version      = $::envconsul::params::version,
+  $platform     = $::envconsul::params::platform,
+  $arch         = $::envconsul::params::arch,
+  $releases_url = $::envconsul::params::releases_url,
+  $base_name    = $::envconsul::params::base_name,
+  $extension    = $::envconsul::params::extension,
+) inherits ::envconsl::params {
 
   include wget
   include envconsul::fetch

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,8 @@
+class envconsul::params {
+  $version      = '0.5.0'
+  $platform     = 'linux'
+  $arch         = 'amd64'
+  $releases_url = 'https://releases.hashicorp.com/envconsul/'
+  $base_name    = "envconsul_${version}"
+  $extension    = ".zip"
+}


### PR DESCRIPTION
I added a params class so all the variables are in one place and I extended the interface of `envconsul` so in the future users can override things like releases_url, extension.

I also changed the defaults to match where hashicorp is currently hosting their binaries.
