### PR TITLE
Conditionally download envconsul

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
- - 2.2.4
+ - 2.2.5
 script: bundle exec rake spec

--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -13,5 +13,7 @@ class envconsul::fetch (
     destination => "/tmp/${file_name}",
     timeout     => 600,
     verbose     => true,
+    unless      => "test -x /usr/bin/envconsul && /usr/bin/envconsul --version 2>&1 | grep -q '${envconsul::version}'",
+    notify      => Exec['unpack'],
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,21 +5,23 @@ class envconsul::install (
 ){
   if $file_name =~ /^.*\.zip/ {
     exec { 'unpack':
-      command => "unzip /tmp/${file_name}",
-      cwd     => '/usr/bin',
-      creates => '/usr/bin/envconsul',
-      path    => ['/bin', '/usr/bin', '/usr/local/bin'],
-      notify  => File['cleanup_file'],
-      require => Class['envconsul::fetch'],
+      command     => "unzip /tmp/${file_name}",
+      cwd         => '/usr/bin',
+      creates     => '/usr/bin/envconsul',
+      path        => ['/bin', '/usr/bin', '/usr/local/bin'],
+      refreshonly => true,
+      notify      => File['cleanup_file'],
+      require     => Class['envconsul::fetch'],
     }
   } elsif $file_name =~ /^.*\.tar\.gz/ {
     exec { 'unpack':
-      command => "tar zxf /tmp/${file_name} --strip-components 1",
-      cwd     => '/usr/bin',
-      creates => '/usr/bin/envconsul',
-      path    => ['/bin', '/usr/bin', '/usr/local/bin'],
-      notify  => File['cleanup_file'],
-      require => Class['envconsul::fetch'],
+      command     => "tar zxf /tmp/${file_name} --strip-components 1",
+      cwd         => '/usr/bin',
+      creates     => '/usr/bin/envconsul',
+      path        => ['/bin', '/usr/bin', '/usr/local/bin'],
+      refreshonly => true,
+      notify      => File['cleanup_file'],
+      require     => Class['envconsul::fetch'],
     }
   }
 


### PR DESCRIPTION
Rather than downloading, installing, and removing the download on every
single Puppet run, only run those steps if /usr/bin/envconsul doesn't
exist, or it's not the correct version.

Also, fix travis build error by bumping the Ruby version up

Sorry about the re-opening, switched forks

/cc @reppard 