### PR TITLE
Fix upgrade bug: Overwrite existing `/usr/bin/envconsul` when `unzip` is used

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,7 +5,7 @@ class envconsul::install (
 ){
   if $file_name =~ /^.*\.zip/ {
     exec { 'unpack':
-      command     => "unzip /tmp/${file_name}",
+      command     => "unzip -o /tmp/${file_name}",
       cwd         => '/usr/bin',
       creates     => '/usr/bin/envconsul',
       path        => ['/bin', '/usr/bin', '/usr/local/bin'],


### PR DESCRIPTION
Unlike `tar`, `unzip` does not overwrite by default.  Adding `-o` allows
encvonsul upgrades to function correctly