### PR TITLE
Allow upgrading envconsul

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,7 +5,7 @@ class envconsul::install (
 ){
   if $file_name =~ /^.*\.zip/ {
     exec { 'unpack':
-      command     => "unzip /tmp/${file_name}",
+      command     => "unzip -o /tmp/${file_name}",
       cwd         => '/usr/bin',
       path        => ['/bin', '/usr/bin', '/usr/local/bin'],
       refreshonly => true,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,7 +7,6 @@ class envconsul::install (
     exec { 'unpack':
       command     => "unzip /tmp/${file_name}",
       cwd         => '/usr/bin',
-      creates     => '/usr/bin/envconsul',
       path        => ['/bin', '/usr/bin', '/usr/local/bin'],
       refreshonly => true,
       notify      => File['cleanup_file'],
@@ -17,7 +16,6 @@ class envconsul::install (
     exec { 'unpack':
       command     => "tar zxf /tmp/${file_name} --strip-components 1",
       cwd         => '/usr/bin',
-      creates     => '/usr/bin/envconsul',
       path        => ['/bin', '/usr/bin', '/usr/local/bin'],
       refreshonly => true,
       notify      => File['cleanup_file'],

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -5,7 +5,7 @@ describe 'envconsul::install' do
     let(:params) { { :file_name => 'file.zip' } }
 
     it { is_expected.to contain_exec('unpack')
-          .with( :command => 'unzip /tmp/file.zip')
+          .with( :command => 'unzip -o /tmp/file.zip')
     }
   end
 


### PR DESCRIPTION
This PR does two things:
1. Removes the `creates` block from `exec`, which prevents the block from being run if the file already exists
2. Adds `-o` to the `unzip` command so that we can overwrite the old version of `envconsul`

I've verified that upgrading works and that subsequent runs do not re-download the file (i.e. that the `unless` block in `fetch` still works)