### PR TITLE
adding attribute to file resource in install.pp

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -27,6 +27,7 @@ class envconsul::install (
 
   file { 'cleanup_file':
     ensure => absent,
+    backup => false,
     path   => "/tmp/${file_name}",
   }
 }


### PR DESCRIPTION
Currently getting these errors from mismatching checksums.  Since this is a publicly available file I don't see a need to create a backup before deleting it.

Notice: /Stage[main]/Envconsul::Fetch/Wget::Fetch[file_url]/Exec[wget-file_url]/returns: executed successfully
Error: Could not back up /tmp/envconsul_0.5.0_linux_amd64.zip: Got passed new contents for sum {md5}ff00ef07ad419f29d79d0825ce7fbea2
Error: Could not back up /tmp/envconsul_0.5.0_linux_amd64.zip: Got passed new contents for sum {md5}ff00ef07ad419f29d79d0825ce7fbea2
Error: /Stage[main]/Envconsul::Install/File[cleanup_file]/ensure: change from file to absent failed: Could not back up /tmp/envconsul_0.5.0_linux_amd64.zip: Got passed new contents for sum {md5}ff00ef07ad419f29d79d0825ce7fbea2
Notice: Finished catalog run in 1.75 seconds
+ ecode=6
+ '[' 6 -eq 4 -o 6 -eq 6 ']'
+ echo 'ERROR: puppet run failed'
ERROR: puppet run failed
+ exit 1

